### PR TITLE
context для отображения массивов и объектов в сообщениях Пачки

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Add the new driver type in your `config/logging.php` configuration
         'via' => SavenkovDev\PachcaLogger\PachcaLogger::class,
         'webhook' => env('LOG_PACHCA_WEBHOOK_URL'),
         'level' => env('LOG_LEVEL', 'debug'),
+        'maxDepth' => env('LOG_PACHCA_MAX_DEPTH', 2),
     ],
 ],
 ```

--- a/src/PachcaHandler.php
+++ b/src/PachcaHandler.php
@@ -116,7 +116,7 @@ class PachcaHandler extends AbstractProcessingHandler
             } elseif ($context instanceof stdClass) {
                 $context = (array)$context;
             } else {
-                $context = (array)$context; // not tested
+                $context = (array)$context; // not tested properly
             }
         }
 
@@ -145,11 +145,13 @@ class PachcaHandler extends AbstractProcessingHandler
                     $depth--;
                 } else {
                     if (is_string($value)) {
-                        $text .= "'" . $value . "'";
+                        $text .= "`" . $value . "`";
                     } elseif (is_bool($value)) {
                         $text .= $value ? "true" : "false";
                     } elseif (is_null($value)) {
                         $text .= "null";
+                    } elseif (is_int($value)) {
+                        $text .= $value;
                     } else {
                         $text .= $value;
                     }

--- a/src/PachcaHandler.php
+++ b/src/PachcaHandler.php
@@ -3,31 +3,60 @@
 namespace SavenkovDev\PachcaLogger;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\RequestOptions;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\LogRecord;
+use stdClass;
+use Throwable;
 
 class PachcaHandler extends AbstractProcessingHandler
 {
+    private int $maxDepth;
     private string $webhook;
     private string $name;
     private Client $guzzle;
 
-    public function __construct($webhook, $name, $level = 'debug', $bubble = true)
+    public function __construct($webhook, $name, $level = 'debug', $bubble = true, $maxDepth = 2)
     {
+        $this->maxDepth = $maxDepth;
         $this->name = $name;
         $this->webhook = $webhook;
         $this->guzzle = new Client();
+
         parent::__construct($level ,$bubble);
+    }
+
+    protected function getContext(array|LogRecord $record): ?string
+    {
+        if ($this->isStacktrace()) {
+            return null;
+        }
+
+        $context = $record['context'] ?? null;
+
+        if (!$context) {
+            return null;
+        }
+
+        if (!is_array($context) && !is_object($context)) {
+            return null;
+        }
+
+        $text = $this->normalizeContext($context);
+
+        return "```php\n" . $text . "\n```";
     }
 
     protected function getStacktrace(array|LogRecord $record): ?string
     {
-        if (!is_subclass_of($record['context']['exception'] ?? '', \Throwable::class))
-        {
+        if (!$this->isStacktrace()) {
             return null;
         }
-        /** @var \Throwable $exception */
+        /** @var Throwable $exception */
         $exception = $record['context']['exception'];
 
         return "On {$exception->getFile()}:{$exception->getLine()} (code {$exception->getCode()})\n" .
@@ -35,9 +64,13 @@ class PachcaHandler extends AbstractProcessingHandler
             $exception->getTraceAsString();
     }
 
+    /**
+     * @throws GuzzleException
+     */
     protected function write(array|LogRecord $record): void
     {
         $stacktrace = $this->getStacktrace($record);
+        $context = $this->getContext($record);
         $header = ($record['level'] >= 400 ? "💥 " : "ℹ️ ") . $record['level'] . " from " . $this->name;
         $message = $header . PHP_EOL . PHP_EOL;
         if ($record['message']) {
@@ -46,10 +79,97 @@ class PachcaHandler extends AbstractProcessingHandler
         if (!empty($stacktrace)) {
             $stacktrace = str_replace('->', '→', $stacktrace);
             $message .= $stacktrace  . PHP_EOL .  PHP_EOL;
+        } elseif (!empty($context)) {
+            $message .= $context  . PHP_EOL .  PHP_EOL;
         }
-        $log = [
-            'message' =>  $message . '---------------------------------------------------------------------------------------------',
-        ];
-        $this->guzzle->request('POST', $this->webhook, [RequestOptions::JSON => $log]);
+
+        $this->guzzle->request('POST', $this->webhook, [
+            RequestOptions::JSON => [
+                'message' =>  $message
+            ]
+        ]);
+    }
+
+    private function normalizeContext(array|object $context, int $depth = 0): string
+    {
+        if (is_array($context)) {
+            $openWith = '[';
+            $closeWith = ']';
+            $delimiter = ': ';
+        } elseif (is_object($context)) {
+            $openWith = '{';
+            $closeWith = '}';
+            $delimiter = ': ';
+        } else {
+            return '';
+        }
+
+        $text = '';
+
+        $class = is_object($context) ? get_class($context) : '';
+
+        if (is_object($context)) {
+            if ($context instanceof Model) {
+                $context = $context->toArray();
+            } elseif ($context instanceof Collection) {
+                $context = $context->toArray();
+            } elseif ($context instanceof stdClass) {
+                $context = (array)$context;
+            } else {
+                $context = (array)$context; // not tested
+            }
+        }
+
+        if ($class) {
+            $text .= "$class: ";
+        }
+
+        $text .= "$openWith\n";
+
+        if ($depth > $this->maxDepth) {
+            $text .= str_repeat("\t", $depth + 1);
+            $text .= "...\n";
+        } else {
+            $isAssoc = Arr::isAssoc($context);
+
+            foreach ($context as $key => $value) {
+                $text .= str_repeat("\t", $depth + 1);
+                if ($isAssoc) {
+                    $text .= $key;
+                    $text .= $delimiter;
+                }
+
+                if (is_array($value) || is_object($value)) {
+                    $depth++;
+                    $text .= $this->normalizeContext($value, $depth);
+                    $depth--;
+                } else {
+                    if (is_string($value)) {
+                        $text .= "'" . $value . "'";
+                    } elseif (is_bool($value)) {
+                        $text .= $value ? "true" : "false";
+                    } elseif (is_null($value)) {
+                        $text .= "null";
+                    } else {
+                        $text .= $value;
+                    }
+
+                    if ($key < count($context)) {
+                        $text .= ",";
+                    }
+                    $text .= "\n";
+                }
+            }
+        }
+
+        $text .= str_repeat("\t", $depth);
+        $text .= "$closeWith\n";
+
+        return $text;
+    }
+
+    private function isStacktrace() : bool
+    {
+        return is_subclass_of($record['context']['exception'] ?? '', Throwable::class);
     }
 }

--- a/src/PachcaHandler.php
+++ b/src/PachcaHandler.php
@@ -64,15 +64,21 @@ class PachcaHandler extends AbstractProcessingHandler
             $exception->getTraceAsString();
     }
 
+    protected function getHeader(array|LogRecord $record): string
+    {
+        return ($record['level'] >= 400 ? "💥 " : "ℹ️ ")/* . $record['level'] . " from " . $this->name*/;
+    }
+
     /**
      * @throws GuzzleException
      */
     protected function write(array|LogRecord $record): void
     {
+        $header     = $this->getHeader($record);
+        $context    = $this->getContext($record);
         $stacktrace = $this->getStacktrace($record);
-        $context = $this->getContext($record);
-        $header = ($record['level'] >= 400 ? "💥 " : "ℹ️ ") . $record['level'] . " from " . $this->name;
-        $message = $header . PHP_EOL . PHP_EOL;
+
+        $message = $header/* . PHP_EOL . PHP_EOL*/;
         if ($record['message']) {
             $message .= $record['message'] . PHP_EOL .  PHP_EOL;
         }

--- a/src/PachcaLogger.php
+++ b/src/PachcaLogger.php
@@ -11,7 +11,7 @@ class PachcaLogger
     {
         $log = new Logger('pachca');
 
-        $log->pushHandler(new PachcaHandler($config['webhook'], config('app.name'), $config['level'] ?? Level::Debug, true));
+        $log->pushHandler(new PachcaHandler($config['webhook'], config('app.name'), $config['level'] ?? Level::Debug, true, $config['maxDepth'] ?? 2));
 
         return $log;
     }


### PR DESCRIPTION
Привет!
Добавил сабж, сделал несколько тестов.
Всё ещё есть проблема отображения символов в сообщениях Пачки, которые кодятся в html entities при кодировании в json. То есть >, <, ', " и другие. Написал в техподдержку по этому поводу, может быть что-то сделают